### PR TITLE
FIX: Player movement when rotated at start

### DIFF
--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -50,7 +50,7 @@ func _physics_process(delta):
 
 	# Get the input direction and handle the movement/deceleration.
 	var input_dir = Input.get_vector("left", "right", "up", "down")
-	var direction = (head.transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
+	var direction = (head.transform.basis * transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
 	if is_on_floor():
 		if direction:
 			velocity.x = direction.x * speed


### PR DESCRIPTION
If Player's node rotation is different from Vector3.ZERO - the character's movement is broken.